### PR TITLE
fix: idea pycharm to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,4 +129,4 @@ dmypy.json
 .pyre/
 
 # PyCharm hidden directory
-.idea
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# PyCharm hidden directory
+.idea


### PR DESCRIPTION
Adicionei o diretório `.idea` para o gitignore
- diretório para guardar as configurações locais

